### PR TITLE
add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: release package on tagged ref
+
+on:
+  push:
+    branches:
+      - 'main'
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "20"
+      - name: Display Tag Information
+        run: |
+          echo "Triggered by tag: ${{ github.ref_name }}"
+          echo "On main branch: ${{ github.ref == 'refs/heads/main' }}"
+      - run: npm ci
+      - name: bundle
+        run: |
+          yarn build
+      - uses: JS-DevTools/npm-publish@v3
+        with:
+          token: ${{ secrets.NPM_CD_TOKEN }}


### PR DESCRIPTION
The PR configures GHA for a tagged release.

The full automation for the release is not applied to the repository, because the package versioning is manually done for the repo.
This will be discuessed in the separated issue.